### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+* text=auto
+
+.gitattributes export-ignore
+.gitignore export-ignore
+
+.babelrc export-ignore
+.csscomb.json export-ignore
+.editorconfig export-ignore
+.eslint* export-ignore
+.jsbeautifyrc export-ignore
+.php_cs.cache export-ignore
+.stylelint* export-ignore
+
+composer.lock export-ignore
+Gulpfile.js export-ignore
+phpcs.xml.dist export-ignore
+phpmd.xml export-ignore
+phpcs.xml.dist export-ignore
+
+/bin export-ignore
+/tests export-ignore


### PR DESCRIPTION
Adding this file will remove the referenced files and folders from a download.

Your users shouldn't need any of these as they are only useful for building the plugin.